### PR TITLE
Fix and update Windows build scripts by DivingDuck

### DIFF
--- a/.github/workflows/buildpackage-mac.yml
+++ b/.github/workflows/buildpackage-mac.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [macos-latest]
         architecture: [x64]
-        python-version: [3.8]
+        python-version: ['3.10']
 
     steps:
     - name: Checkout

--- a/.github/workflows/buildpackage-win.yml
+++ b/.github/workflows/buildpackage-win.yml
@@ -14,12 +14,20 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        architecture: [x64, x86]
-        python-version: [3.8]
+        # remove x86 builds for now as there are no snapshot builds of wxPython available
+        #architecture: [x64, x86]
+        architecture: [x64]
+        # add python '3.10' because wxPython 4.2 is now available (2022-08-21)
+        # remove python '3.6' because not longer supported (2022-03-17)
+        python-version: ['3.7', '3.8', '3.9','3.10']
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      # Import submodule PrintrunGTK3
+      with:
+        submodules: recursive
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
@@ -27,13 +35,50 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip pyinstaller setuptools wheel cython cffi -r requirements.txt
+        python -m pip install --upgrade pip pyinstaller setuptools wheel simplejson polygon3 cython cffi -r requirements.txt
+
+   # - name: Update to wxPython Version for x86 and py 3.8
+   #   # Latest development version for x86 and Python 3.6 is for now (2021-12-18) 4.1.2a1.dev5226+a843ed14
+   #   # Latest development version for x86 and Python 3.8+3.9 is for now (2022-03-17) 4.1.2a1.dev5226+a843ed14
+   #   # Remove Python 3.6
+   #   if: ${{ matrix.architecture == 'x86' && matrix.python-version == '3.8' }}
+   #   run: |
+   #     python -m pip install -U --pre -f https://wxpython.org/Phoenix/snapshot-builds/ wxPython==4.1.2a1.dev5226+a843ed14
+   # - name: Update to wxPython Version for x86 and py 3.9
+   #   # Latest development version for x86 and Python 3.6 is for now (2021-12-18) 4.1.2a1.dev5226+a843ed14
+   #   # Latest development version for x86 and Python 3.8+3.9 is for now (2022-03-17) 4.1.2a1.dev5226+a843ed14
+   #   # Remove Python 3.6
+   #   if: ${{ matrix.architecture == 'x86' && matrix.python-version == '3.9' }}
+   #   run: |
+   #     python -m pip install -U --pre -f https://wxpython.org/Phoenix/snapshot-builds/ wxPython==4.1.2a1.dev5226+a843ed14
+   # 
+   #     
+    - name: Update to wxPython latest Version for x64
+      # Latest development version for x64 and Python 3.7 to 3.10, can be removed if requirements.txt is fixed
+      if: ${{ matrix.architecture == 'x64' && matrix.python-version >= '3.7' }}
+      run: |
+        # python -m pip install -U --pre -f https://wxpython.org/Phoenix/snapshot-builds/ wxPython
+        python -m pip install -U wxPython
+
     - name: Build Cython ext
       run: |
         python setup.py build_ext --inplace
-    - name: Make pyinstaller spec
+    # Build pyinstaller spec depending on GTK3 x32/x64 binaries or w/o GTK3 bundle
+    # for running Projector. The user can install the GTK3 libraries external and 
+    # set the environment path to the installation manually if the bundle is not 
+    # included or found (last option) via submodules
+    - name: Make pyinstaller spec with GTK3 x64 bundle
+      if: ${{ matrix.architecture == 'x64' && hashFiles('PrintrunGTK3/GTK3Windows10-64') != '' }}
       run: |
-        pyi-makespec --hidden-import="pkg_resources.py2_warn" -F --add-data "images/*;images" --add-data "*.png;." --add-data "*.ico;." -w -i pronterface.ico pronterface.py
+        pyi-makespec --hidden-import="pkg_resources.py2_warn" -F --add-binary "PrintrunGTK3/GTK3Windows10-64/*.dll;." --add-data "VERSION;cairocffi" --add-data "VERSION;cairosvg" --add-data "images/*;images" --add-data "*.png;." --add-data "*.ico;." -w -i pronterface.ico pronterface.py
+    - name: Make pyinstaller spec with GTK3 x32 bundle
+      if: ${{ matrix.architecture == 'x86' && hashFiles('PrintrunGTK3/GTK3Windows10-32') != '' }}
+      run: |
+        pyi-makespec --hidden-import="pkg_resources.py2_warn" -F --add-binary "PrintrunGTK3/GTK3Windows10-32/*.dll;." --add-data "VERSION;cairocffi" --add-data "VERSION;cairosvg" --add-data "images/*;images" --add-data "*.png;." --add-data "*.ico;." -w -i pronterface.ico pronterface.py
+    - name: Make pyinstaller spec without GTK3 bundle
+      if: ${{ hashFiles('PrintrunGTK3') == '' }}
+      run: |
+        pyi-makespec --hidden-import="pkg_resources.py2_warn" -F --add-data "VERSION;cairocffi" --add-data "VERSION;cairosvg" --add-data "images/*;images" --add-data "*.png;." --add-data "*.ico;." -w -i pronterface.ico pronterface.py
     - name: Make pyinstaller build
       run: |
         pyinstaller --clean pronterface.spec -y

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ uploads
 .vagrant
 prontserve-env
 pronterface.spec
+pronsole.spec
 printrun/gcoder_line.c
 printrun/gcoder_line*.so
 printrun/gcoder_line*.pyd
@@ -24,3 +25,6 @@ printrun/gcoder_line*.pyd
 /.vs/
 /dist
 /slic3rconf.ini
+/PrusaSlicer.ini
+/.eggs
+/SuperSlicer.ini

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "PrintrunGTK3"]
+	path = PrintrunGTK3
+	url = https://github.com/DivingDuck/PrintrunGTK3

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,61 @@
+This is a dummy file for pyinstaller to compile Pronterface.Cairocffi and cairosvg won't find
+the GTK3 runtime libraries needed for running Projector under Windows w / o this file.
+
+You can find a suitable version of GTK3 for Windows 10 here : https://github.com/DivingDuck/PrintrunGTK3.
+For further information please follow the links.PrintrunGTK3 is a submodule of Printrun.
+
+The DLL binaries are based on https ://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer
+for 64 Bit version and http ://www.tarnyko.net/dl/gtk.htm for 32 Bit version and are not modified.
+
+	Please run following git commands in case you can't find the directory 'PrintrunGTK' in your repository:
+	git checkout master
+	git submodule add https ://github.com/DivingDuck/PrintrunGTK3
+git submodule update --init --recursive
+
+For updating an existing submodule to latest version run :
+git submodule update --remote
+
+Compiling Pronterface manually :
+Follow the instructions in release_windows.bat and activate the correct pyi - makespec version depending on your needs.
+
+
+List of DLL's for Projector based on Windows 10 for 64bit program version:
+--------------------------------------------------------------------------
+https ://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer
+    https ://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/releases/download/2021-01-30/gtk3-runtime-3.24.24-2021-01-30-ts-win64.exe
+
+	libbrotlicommon.dll
+	libbrotlidec.dll
+	libbz2 - 1.dll
+	libcairo - 2.dll
+	libexpat - 1.dll
+	libfontconfig - 1.dll
+	libfreetype - 6.dll
+	libgcc_s_seh - 1.dll
+	libglib - 2.0 - 0.dll
+	libgraphite2.dll
+	libharfbuzz - 0.dll
+	libiconv - 2.dll
+	libintl - 8.dll
+	libpcre - 1.dll
+	libpixman - 1 - 0.dll
+	libpng16 - 16.dll
+	libstdc++ - 6.dll
+	libwinpthread - 1.dll
+	zlib1.dll
+
+
+	List of DLL's for Projector based on Windows 10 for 32bit program version:
+	--------------------------------------------------------------------------
+	http ://www.tarnyko.net/dl/gtk.htm
+http://www.tarnyko.net/repo/gtk3_build_system/gtk+-bundle_3.6.4-20130513_win32.zip
+
+File list :
+libcairo - 2.dll
+libexpat - 1.dll
+libfontconfig - 1.dll
+libfreetype - 6.dll
+libpixman - 1 - 0.dll
+libpng15 - 15.dll
+Remark.txt
+zlib1.dll

--- a/printrun/gcview.py
+++ b/printrun/gcview.py
@@ -471,12 +471,15 @@ class GcodeViewFrame(GvizBaseFrame, GcodeViewLoader):
         wx.CallAfter(self.SetStatusText, message, 0)
 
     def process_slider(self, event):
-        new_layer = self.layerslider.GetValue()
-        new_layer = min(self.model.max_layers + 1, new_layer)
-        new_layer = max(1, new_layer)
-        self.model.num_layers_to_draw = new_layer
-        self.update_status("")
-        wx.CallAfter(self.Refresh)
+        if self.model is not None:
+            new_layer = self.layerslider.GetValue()
+            new_layer = min(self.model.max_layers + 1, new_layer)
+            new_layer = max(1, new_layer)
+            self.model.num_layers_to_draw = new_layer
+            self.update_status("")
+            wx.CallAfter(self.Refresh)
+        else:
+            logging.info(_("G-Code view, can't process slider. Please wait until model is loaded completely."))
 
     def set_current_gline(self, gline):
         if gline.is_move and gline.gcview_end_vertex is not None \

--- a/printrun/projectlayer.py
+++ b/printrun/projectlayer.py
@@ -109,7 +109,9 @@ class DisplayFrame(wx.Frame):
                 if self.layer_red:
                     pngImage = pngImage.AdjustChannels(1, 0, 0, 1)
 
-                dc.DrawBitmap(wx.Bitmap(pngImage), self.offset[0], self.offset[1], True)
+                # AGE2022-07-31 Python 3.10 and DrawBitmap expects offset 
+                # as integer value. Convert float values to int
+                dc.DrawBitmap(wx.Bitmap(pngImage), int(self.offset[0]), int(self.offset[1]), True)
 
             elif self.slicer == 'bitmap':
                 if isinstance(image, str):
@@ -130,16 +132,18 @@ class DisplayFrame(wx.Frame):
             pass
 
     def show_img_delay(self, image):
-        print("Showing", str(time.clock()))
+        print("Showing", str(time.perf_counter()))
         self.control_frame.set_current_layer(self.index)
         self.draw_layer(image)
-        wx.FutureCall(1000 * self.interval, self.hide_pic_and_rise)
+        # AGe 2022-07-31 Python 3.10 and CallLater expects delay in millyseconds as 
+        # integer value instead of float. Convert float value to int
+        wx.CallLater(int(1000 * self.interval), self.hide_pic_and_rise)
 
     def rise(self):
         if self.direction == "Top Down":
-            print("Lowering", str(time.clock()))
+            print("Lowering", str(time.perf_counter()))
         else:
-            print("Rising", str(time.clock()))
+            print("Rising", str(time.perf_counter()))
 
         if self.printer is not None and self.printer.online:
             self.printer.send_now("G91")
@@ -165,15 +169,16 @@ class DisplayFrame(wx.Frame):
         else:
             time.sleep(self.pause)
 
-        wx.FutureCall(1000 * self.pause, self.next_img)
+        # AGe 2022-07-31 Python 3.10 expects delay in millyseconds as integer value instead of float. Convert float value to int
+        wx.CallLater(int(1000 * self.pause), self.next_img)
 
     def hide_pic(self):
-        print("Hiding", str(time.clock()))
+        print("Hiding", str(time.perf_counter()))
         self.pic.Hide()
 
     def hide_pic_and_rise(self):
         wx.CallAfter(self.hide_pic)
-        wx.FutureCall(500, self.rise)
+        wx.CallLater(500, self.rise)
 
     def next_img(self):
         if not self.running:

--- a/release_windows.bat
+++ b/release_windows.bat
@@ -1,40 +1,63 @@
 echo off
 cls
 
-rem *************************************************************************
-rem ****************  ---> New batch file starts here <---  *****************
-rem **                                                                     **
-rem **  This batch will compile automated via command line an executable   **
-rem **  Pronterface file for Windows 10.                                   **
-rem **                                                                     **
-rem **  Steps that are automated:                                          **
-rem **                                                                     **
-rem **  1. clean up previous compilations (directory .\dist)               **
-rem **  2. check for virtual environment called v3 and generate it, if     **
-rem **     not available (start from scratch)                              **
-rem **  3. install all needed additional modules via pip                   **
-rem **  4. check for outdated modules that need to be updated and          **
-rem **     update them                                                     **
-rem **  5. Check if virtual environment needs an update and do it          **
-rem **  6. check for existing variants of gcoder_line.cp??-win_amd??.pyd   **
-rem **     and delete them (to prevent errors and incompatibilities)       **
-rem **  7. compile Pronterface.exe                                         **
-rem **  8. copy localization files to .\dist                               **
-rem **  9. go to directory .\dist, list files and ends the activity        **
-rem **                                                                     **
-rem **  Steps, you need to do manually before running this batch:          **
-rem **                                                                     **
-rem **  1. install python 3.7.9                                            **
-rem **     https://www.python.org/downloads/release/python-378/            **
-rem **  2. install C-compiler environment                                  **
-rem **     https://wiki.python.org/moin/WindowsCompilers                   **
-rem **  3. check for latest repository updates at:                         **
-rem **     http://github.com/kliment/Printrun.git                          **
-rem **                                                                     **
-rem **  Author: DivingDuck, 2021-01-06, Status: working                    **
-rem **                                                                     **
-rem *************************************************************************
-rem *************************************************************************
+rem ************************************************************************************
+rem *********************  ---> New batch file starts here <---  ***********************
+rem **                                                                                **
+rem **  This batch will compile automated via command line an executable              **
+rem **  Pronterface- and Pronsole file for Windows 10.                                **
+rem **                                                                                **
+rem **  Steps that are automated:                                                     **
+rem **                                                                                **
+rem **   1. Clean up previous compilations (directory .\dist)                         **
+rem **   2. Check for virtual environment called v3 and generate it, if               **
+rem **      not available (start from scratch)                                        **
+rem **   3. Install all needed additional modules via pip                             **
+rem **   4. Check for outdated modules that need to be updated and                    **
+rem **      update them                                                               **
+rem **   5. Check if virtual environment needs an update and do it                    **
+rem **   6. Check for existing variants of gcoder_line.cp??-win_amd??.pyd             **
+rem **      and delete them (to prevent errors and incompatibilities)                 **
+rem **   7. Compile Pronterface.exe                                                   **
+rem **   8. Compile Pronsole.exe                                                      **
+rem **   9. Copy localization files to .\dist                                         **
+rem **  10. Go to directory .\dist, list files and ends the activity                  **
+rem **                                                                                **
+rem **  Steps, you need to do manually before running this batch:                     **
+rem **                                                                                **
+rem **  1. Install python 64-bit (3.10.x is actually preferred version for            **
+rem **     Windows 10 and newer)                                                      **
+rem **     https://www.python.org/downloads/release/python-379/                       **
+rem **     In case you use an other Python version, check line 88  and adjust         **
+rem **     the parameter accordingly to build your virtual environment.               **
+rem **  2. Install C-compiler environment                                             **
+rem **     https://wiki.python.org/moin/WindowsCompilers                              **
+rem **  3. Check for latest repository updates at:                                    **
+rem **     http://github.com/kliment/Printrun.git                                     **
+rem **  4. Projector needs GTK+ for Windows Runtime Environment installed.            **
+rem **     There are different compilations, depending on the installed               **
+rem **     Windows version, available. You can find a striped version of GTK3         **
+rem **     with all needed DLL binary files in directory PrintrunGTK. Please run      **
+rem **     following git commands before you run this batch in case you don't find    **
+rem **     this directory in your local repository:                                   **
+rem **       git checkout master                                                      ** 
+rem **       git submodule add https://github.com/DivingDuck/PrintrunGTK3             **
+rem **       git submodule update --init --recursive                                  **
+rem **     You can find a listing of all used DLL's in file VERSION as reference and  **
+rem **     further informations about the linked submodule here:                      **
+rem **     https://github.com/DivingDuck/PrintrunGTK3                                 **
+rem **                                                                                **
+rem **     Follow the instructions at section 'Collect all data for build' below      **
+rem **                                                                                **
+rem **   Remark: wxPython drops support x32 builders. Only x64 versions for now       **
+rem **                                                                                **
+rem **   https://github.com/wxWidgets/Phoenix/commit/d3bdb14365ca754e83732cccd04e94a2ded5029f
+rem **                                                                                **
+rem **                                                                                **
+rem **  Author: DivingDuck, 2023-01-31, Status: working                               **
+rem **                                                                                **
+rem ************************************************************************************
+rem ************************************************************************************
 
 echo **************************************************
 echo ****** Delete files and directory of .\dist ******
@@ -54,14 +77,23 @@ if exist v3 (
    echo ****** No virtual environment named v3 available                ******
    echo ****** Will create first a new virtual environment with name v3 ******
    echo **********************************************************************
-   py -3.7 -m venv v3
+   rem Select your Python version below. Remove 'rem' before 'rem py -3.x ...' for
+   rem your Python version of choice and add 'rem' for all other versions.
+   rem Attention: 
+   rem Minimum version for wxPython is >= 4.2 and with this version only
+   rem Python x64 versions are supported.
 
+   rem py -3.7 -m venv v3
+   rem py -3.8 -m venv v3
+   rem py -3.9 -m venv v3
+   py -3.10 -m venv v3
+   
    echo *********************************************
    echo ****** Activate virtual environment v3 ******
    echo *********************************************
    call v3\Scripts\activate
 
-   pip install --upgrade pip
+   py -m pip install --upgrade pip
    pip install --upgrade setuptools
 
    pip install wheel
@@ -69,21 +101,13 @@ if exist v3 (
    echo **********************************
    echo ****** install requirements ******
    echo **********************************
-   pip install -r requirements.txt
    pip install cython
+   pip install -r requirements.txt
+   
    echo ***********************
    echo ****** additions ******
    echo ***********************
    pip install simplejson
-   
-   rem echo *******************************
-   rem echo ****** pyinstaller 4 dev ******
-   rem echo *******************************
-   rem pyinstaller v3.6 don't work with Windows 10  pip install pyinstaller
-   rem update 2020-12-13: there is a new version available v4.1. 
-   rem Looks like we don't need this fix any longer
-   REM pip uninstall pyinstaller
-   REM pip install https://github.com/pyinstaller/pyinstaller/archive/develop.zip
    pip install pyinstaller
    pip install pypiwin32
    pip install polygon3
@@ -93,24 +117,34 @@ echo ********************************************
 echo ****** upgrade virtual environment v3 ******
 echo ********************************************
 pip install --upgrade virtualenv
-
+ 
 echo ****************************************************
 echo ****** check for and update outdated modules  ******
 echo ****************************************************
-for /F "skip=2 delims= " %%i in ('pip list --outdated') do pip install --upgrade %%i
+for /F "skip=2 delims= " %%i in ('pip list --outdated') do py -m pip install --upgrade %%i
 
-rem echo ****************************************************************************************
-rem echo ****** --->> Hotfix AGe: solve numpy 1.19.4 problem for x64 windows runtime error ******
-rem echo ****************************************************************************************
-rem numpy v1.19.4 create an python RuntimeError: The current Numpy installation fails to pass a 
-rem sanity check due to a bug in the windows runtime. See this issue for more information:
-rem https://tinyurl.com/y3dm3h86
-rem Temporary workaround is to install 1.19.3 instead.
-rem --> ToDo: Need to be checked in 2021 January again
-rem update 2021-01-06: There is a new version available
-rem --> Solved with version 1.19.5
-rem pip uninstall numpy
-rem pip install numpy==1.19.3
+echo ****************************************************************************
+echo ****** Bug on wxPython 4.1.x workaround for Python 3.x and Windows 10 ******
+echo ****************************************************************************
+rem wxPython 4.2.0 is available. Snapshot version is not needed now. Hopefully.  #2022-08-05
+rem pip install -U --pre -f https://wxpython.org/Phoenix/snapshot-builds/ wxPython
+
+echo *************************************************************************
+echo ****** pyglet workaround, needs to be below 2.0 (isn't compatible) ******
+echo *************************************************************************
+rem # 2022-11-01
+pip uninstall pyglet -y
+pip install pyglet==1.5.27
+
+
+echo *****************************************************************************
+echo ****** cairosvg workaround, needs to be below 2.6.0 (isn't compatible) ******
+echo *****************************************************************************
+rem # 2023-01-30
+rem cairosvg 2.6.0 have problems with locale, so we will stay to 2.5.2 as workaround for now
+pip uninstall cairosvg -y
+pip install cairosvg==2.5.2
+
 
 echo ******************************************************************
 echo ****** Compile G-Code parser gcoder_line.cp37-win_amd64.pyd ******
@@ -127,12 +161,46 @@ python setup.py build_ext --inplace
 echo ****************************************
 echo ****** Collect all data for build ******
 echo ****************************************
-pyi-makespec -F --add-data images/*;images --add-data *.png;. --add-data *.ico;. -w -i pronterface.ico pronterface.py
 
-echo *******************************
-echo ****** Build Pronterface ******
-echo *******************************
+rem **** Select which version you want to build: ****
+rem The Projector feature of Pronterface need some external DLL binaries from the GTK3.
+rem You can build Pronterface with or w/o these binaries. In addition you need
+rem different binaries depending if you build a Windows 10 x32 or x64 version.
+rem Remove 'rem' before pyi-makespec for the build of your choice and add 'rem'
+rem for all other versions. You can't bundle x32 and x46 into the same Pronterface binary file.
+rem Only one active version is allowed. 
+
+rem **** Default setup: Version 3, GTK3 bundle included for Windows 10 x64 bit.  ****
+
+rem Version 1: With external GTK3 or w/o GTK3 support: 
+rem Choose this pyi-makespec in case you don't have the GTK3 Toolkit files, or want them stay separately
+rem or don't want to bundle these within Pronterface.exe. You can install them separately and 
+rem set the path location via Windows system environment variable (like Path=c:\GTK3\bin).
+
+rem pyi-makespec -F --add-data VERSION;cairocffi --add-data VERSION;cairosvg --add-data images/*;images --add-data *.png;. --add-data *.ico;. -w -i pronterface.ico pronterface.py
+rem pyi-makespec -F --add-data VERSION;cairocffi --add-data VERSION;cairosvg --add-data images/*;images --add-data *.png;. --add-data *.ico;. -c -i pronsole.ico pronsole.py
+
+rem Version 2: GTK3 included in Pronterface (Windows10 x32 only) NOT Supported for now (see wxPython remark line 51):
+rem Choose this pyi-makespec in case you want to include the GTK3 Toolkit files for Windows10 x32 only
+
+rem pyi-makespec -F --add-binary PrintrunGTK3/GTK3Windows10-32/*.dll;. --add-data VERSION;cairocffi --add-data VERSION;cairosvg --add-data images/*;images --add-data *.png;. --add-data *.ico;. -w -i pronterface.ico pronterface.py
+rem pyi-makespec -F --add-binary PrintrunGTK3/GTK3Windows10-32/*.dll;. --add-data VERSION;cairocffi --add-data VERSION;cairosvg --add-data images/*;images --add-data *.png;. --add-data *.ico;. -c -i pronsole.ico pronsole.py
+
+rem Version 3: GTK3 included in Pronterface (Windows10 x64 only):
+rem Choose this pyi-makespec in case you want to include the GTK3 Toolkit files for Windows10 x64 only
+
+pyi-makespec -F --add-binary PrintrunGTK3/GTK3Windows10-64/*.dll;. --add-data VERSION;cairocffi --add-data VERSION;cairosvg --add-data images/*;images --add-data *.png;. --add-data *.ico;. -w -i pronterface.ico pronterface.py
+pyi-makespec -F --add-binary PrintrunGTK3/GTK3Windows10-64/*.dll;. --add-data VERSION;cairocffi --add-data VERSION;cairosvg --add-data images/*;images --add-data *.png;. --add-data *.ico;. -c -i pronsole.ico pronsole.py
+
+echo ********************************************************
+echo ****** Build Pronterface and Pronsole executables ******
+echo ********************************************************
+echo
+echo ** Build Pronterface executable **
 pyinstaller --clean pronterface.spec -y
+echo 
+echo ** Build Pronsole executable **
+pyinstaller --clean pronsole.spec -y
 
 echo ********************************
 echo ****** Add language files ******

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 pyserial (>= 3.0)
-wxPython (== 4.1.0)
+wxPython >= 4.2.0
 numpy (>= 1.8.2)
 pyglet >= 1.1, < 2.0
 cffi
 cairocffi
-cairosvg (>= 1.0.9)
+cairosvg >= 1.0.9, < 2.6.0
 psutil (>= 2.1)
 lxml (>= 2.9.1)
 appdirs (>= 1.4.0)


### PR DESCRIPTION
* add pycairo for running projector
* add simplejson polygon3
* Replace time.clock() with time.perf_counter()
* Replace wx.FutureCall with wx.CallLater
* Bundle GTK3 runtime library to Pronterface for Windows 10-64bit
* Make GTK3 a submodule of Printrun, delete GTK3 files from this repository, change buildpackage-win.yml to integrate GTK3 as submodule and compile the correct version GTK3 version for 32-/64-bit or as external reference via windows system environment path
* Add Python 3.10 to github Workflow (windows)
* cairosvg 2.6.0 have problems with locale, so we will stay to version 2.5.2 as workaround for now
* some cleaning for release_windows.bat and update of information in dummy file VERSION